### PR TITLE
add flag for cmake BUILD_SHARED_LIBS option

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,11 +1,10 @@
-
-
-
 # Change Log
 
-
 ## Latest Changes
- - Created package configuration files
- - Missing ref benchmark files changed from ERROR to WARNING in run-nrtests.zsh script
- - Checks added to before-nrtest.zsh script
- - Branch "dev" deprecated
+
+- Created package configuration files
+- Missing ref benchmark files changed from ERROR to WARNING in run-nrtests.zsh script
+- Checks added to before-nrtest.zsh script
+- Branch "dev" deprecated
+- add `-s` flag for cmake BUILD_SHARED_LIBS=OFF option
+- Update windows cmake generator to Visual Studio 2022

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,11 @@ E: caleb.buahin@gmail.com
 L: CC0
 D: Contributor, Linux, bug fix
 
+N: Constantine Karos
+E: ckaros@outlook.com
+L: CC0
+D: Contributor, Windows, Mac OS, Linux, bug fix
+
 N: Michael Tryby
 E: tryby.michael@epa.gov
 L: Public Domain (within US), CC0 (all other jurisdictions)

--- a/darwin/make.zsh
+++ b/darwin/make.zsh
@@ -47,7 +47,7 @@ echo INFO: Building ${PROJECT}  ...
 
 GENERATOR="Xcode"
 TESTING=0
-
+BUILD_SHARED_LIBS=ON
 
 POSITIONAL=()
 
@@ -62,6 +62,10 @@ case $key in
     ;;
     -t|--test)
     TESTING=1
+    shift # past argument
+    ;;
+    -s|--static)
+    BUILD_SHARED_LIBS=OFF
     shift # past argument
     ;;
     *)    # unknown option
@@ -80,13 +84,13 @@ RESULT=$?
 if [ ${TESTING} -eq 1 ];
 then
     echo "Building debug"
-    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=ON .. \
+    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=ON -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS}" .. \
     && cmake --build ./${BUILD_HOME}  --config Debug \
     && cmake -E chdir ./${BUILD_HOME}  ctest -C Debug --output-on-failure
     RESULT=$?
 else
     echo "Building release"
-    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=OFF .. \
+    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS}" .. \
     && cmake --build ./${BUILD_HOME} --config Release --target package
     RESULT=$?
     cp ./${BUILD_HOME}/*.tar.gz ./upload >&1

--- a/linux/make.sh
+++ b/linux/make.sh
@@ -54,6 +54,7 @@ echo INFO: Building ${PROJECT}  ...
 
 GENERATOR="Unix Makefiles"
 TESTING=0
+BUILD_SHARED_LIBS=ON
 
 POSITIONAL=()
 
@@ -67,6 +68,10 @@ case $key in
     ;;
     -t|--test)
     TESTING=1
+    shift # past argument
+    ;;
+    -s|--static)
+    BUILD_SHARED_LIBS=OFF
     shift # past argument
     ;;
     *)    # unknown option
@@ -83,12 +88,12 @@ cmake -E make_directory ${BUILD_HOME}
 RESULT=$?
 
 if [ ${TESTING} -eq 1 ]; then
-    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=ON .. \
+    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=ON -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS}" .. \
     && cmake --build ./${BUILD_HOME}  --config Debug \
     && cmake -E chdir ./${BUILD_HOME}  ctest -C Debug --output-on-failure
     RESULT=$?
 else
-    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=OFF .. \
+    cmake -E chdir ./${BUILD_HOME} cmake -G "${GENERATOR}" -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="${BUILD_SHARED_LIBS}" .. \
     && cmake --build ./${BUILD_HOME} --config Release --target package
     RESULT=$?
     cp ./${BUILD_HOME}/*.tar.gz ./upload >&1

--- a/windows/make.cmd
+++ b/windows/make.cmd
@@ -80,15 +80,23 @@ echo INFO: Building %PROJECT%  ...
 
 
 :: set local defaults
-set "GENERATOR=Visual Studio 15 2017 Win64"
+set "GENERATOR=Visual Studio 17 2022"
 set "TESTING=0"
-
+set "BUILD_SHARED_LIBS=ON"
+set "ARCHITECTURE=x64"
 :: process arguments
 :loop
 if NOT [%1]==[] (
   if "%1"=="/g" (
     set "GENERATOR=%~2"
     shift
+  )
+  if "%1"=="/A" (
+    set "ARCHITECTURE=%~2"
+    shift
+  )
+  if "%1"=="/s" (
+    set "BUILD_SHARED_LIBS=OFF"
   )
   if "%1"=="/t" (
     set "TESTING=1"
@@ -117,7 +125,7 @@ if exist %BUILD_HOME% (
 cmake -E make_directory %BUILD_HOME%
 
 if %TESTING% equ 1 (
-  cmake -E chdir .\%BUILD_HOME% cmake -G"%GENERATOR%" -DBUILD_TESTS=ON ..^
+  cmake -E chdir .\%BUILD_HOME% cmake -G"%GENERATOR%" -A"%ARCHITECTURE%"  -DBUILD_TESTS=ON -DBUILD_SHARED_LIBS="%BUILD_SHARED_LIBS%" ..^
   && cmake --build .\%BUILD_HOME% --config Debug^
   && cmake -E chdir .\%BUILD_HOME% ctest -C Debug --output-on-failure^
   || (
@@ -125,7 +133,7 @@ if %TESTING% equ 1 (
   )
 
 ) else (
-  cmake -E chdir .\%BUILD_HOME% cmake -G"%GENERATOR%" -DBUILD_TESTS=OFF ..^
+  cmake -E chdir .\%BUILD_HOME% cmake -G"%GENERATOR%" -A"%ARCHITECTURE%" -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="%BUILD_SHARED_LIBS%" ..^
   && cmake --build .\%BUILD_HOME% --config Release --target package^
   && (
     move /Y .\%BUILD_HOME%\*.zip .\upload > nul


### PR DESCRIPTION
- add `-s` flag for cmake BUILD_SHARED_LIBS=OFF option
- update windows cmake generator to Visual Studio 2022
- update CONTRIBUTORS
- update change log